### PR TITLE
Support "A" and "a" formatters.

### DIFF
--- a/src/format-date.ts
+++ b/src/format-date.ts
@@ -15,6 +15,8 @@ const FORMATTERS: Record<string, (date: Date) => string> = {
   'm':    date => '' + date.getMinutes(),
   'ss':   date => addZeroPads(2, '' + date.getSeconds()),
   's':    date => '' + date.getSeconds(),
+  'a':    date => '' + (date.getHours() >= 12 ? 'pm' : 'am'),
+  'A':    date => '' + (date.getHours() >= 12 ? 'PM' : 'AM'),
 };
 
 /**


### PR DESCRIPTION
I added formatters for "A" and "a" to support "PM/AM" and "pm/am".